### PR TITLE
fix(template): busy template path

### DIFF
--- a/src/busy.js
+++ b/src/busy.js
@@ -33,7 +33,7 @@ export class Busy {
   }
 
   async createBusyView() {
-    let factory = await this.viewEngine.loadViewFactory('widgets/busy/busy.html');
+    let factory = await this.viewEngine.loadViewFactory('busy.html');
     const childContainer = this.container.createChild();
     this.view = factory.create(childContainer);
     this.view.bind(this);


### PR DESCRIPTION
The template path used to create a view factory for the busy indicator was wrong.